### PR TITLE
App.js 의 state 이름의 state를 mainState로 이름 변경 등

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ import Result from 'view/result';
 import Description from 'view/Description';
 
 function App() {
-  const [state, setState] = useState(APP_STATE.HOME);
+  const [mainState, setMainState] = useState(APP_STATE.HOME);
   const [type, setType] = useState('');
 
   /**
@@ -18,8 +18,8 @@ function App() {
    * @author  uhjee
    */
   useEffect(() => {
-    if (state && state === APP_STATE.HOME) setType('');
-  }, [state]);
+    if (mainState && mainState === APP_STATE.HOME) setType('');
+  }, [mainState]);
 
   return (
     <BrowserRouter>
@@ -27,14 +27,14 @@ function App() {
         <>
           <div
             className={`main-container${
-              state === APP_STATE.DESC ? ' olive' : ''
+              mainState === APP_STATE.DESC ? ' olive' : ''
             }`}
           >
             <Route
               exact
               path="/"
               render={({ history }) => (
-                <Home history={history} setState={setState} />
+                <Home history={history} setMainState={setMainState} />
               )}
             />
             <Route
@@ -42,7 +42,7 @@ function App() {
               render={({ history }) => (
                 <Research
                   history={history}
-                  setState={setState}
+                  setMainState={setMainState}
                   setType={setType}
                 />
               )}
@@ -54,7 +54,7 @@ function App() {
                 <Result
                   history={history}
                   match={match}
-                  setState={setState}
+                  setMainState={setMainState}
                   type={type}
                 />
               )}
@@ -65,7 +65,7 @@ function App() {
                 <Description
                   type={type}
                   history={history}
-                  setState={setState}
+                  setMainState={setMainState}
                 />
               )}
             />

--- a/src/common/customHooks.js
+++ b/src/common/customHooks.js
@@ -2,6 +2,12 @@ import { useEffect, useRef } from 'react';
 
 import { isNil } from 'utils/commonUtil';
 
+/**
+ * 클릭 이벤트 핸들러 함수를 인자로 받아, 해당 핸들러를 매핑할 ref element를 반환한다.
+ * @author  uhjee
+ * @param {[string]} onClick  클릭 이벤트 핸들러
+ * @returns   {[object]}      클릭 이벤트 등록 객체
+ */
 export const useClick = onClick => {
   if (typeof onClick !== 'function') {
     throw new Error('click 이벤트 콜백함수  - 함수가 아님');
@@ -10,18 +16,27 @@ export const useClick = onClick => {
   const element = useRef();
 
   useEffect(() => {
-    if (element && element.current) {
-      element.current.addEventListener('click', onClick);
+    const _current = element.current;
+    if (element && _current) {
+      _current.addEventListener('click', onClick);
     }
     return () => {
-      if (element && element.current) {
-        element.current.removeEventListener('click', onClick);
+      if (element && _current) {
+        _current.removeEventListener('click', onClick);
       }
     };
-  }, []);
+  });
   return element;
 };
 
+/**
+ * 파라미터로 받는 cb 함수가 delay 이후에 호출되도록 처리한다.
+ * @author  uhjee
+ * @param   {[function]}  callback  지연 콜백
+ * @param   {[number]}  delay     지연할 밀리초
+ *
+ * @return  {[function]}            interval을 종료할 수 있는 함수
+ */
 export const useInterval = (callback, delay) => {
   // useRef를 사용해 가장 마지막 콜백 기억
   const savedCallback = useRef();
@@ -42,4 +57,16 @@ export const useInterval = (callback, delay) => {
       return () => clearInterval(id);
     }
   });
+};
+
+/**
+ * 상태를 변경한다.
+ * @author  uhjee
+ * @param   {[string]}  state     (HOME, RESEARCH, RESULT, DESCRIPTION)
+ * @param   {[function]}  setState  [setState description]
+ */
+export const useMainState = (state, setState) => {
+  useEffect(() => {
+    setState(state);
+  }, [state, setState]);
 };

--- a/src/components/Answer.jsx
+++ b/src/components/Answer.jsx
@@ -1,30 +1,34 @@
-import React, {useEffect, useRef} from 'react';
+import React, { useEffect, useRef } from 'react';
 import '../scss/button.scss';
 import '../scss/answer.scss';
 
-
 const Answer = ({ text, handler }) => {
-    const useClick = onClick => {
-        if (typeof onClick !== 'function') {
-            throw new Error('click 이벤트 콜백함수  - 함수가 아님');
+  const useClick = onClick => {
+    if (typeof onClick !== 'function') {
+      throw new Error('click 이벤트 콜백함수  - 함수가 아님');
+    }
+
+    const element = useRef();
+
+    useEffect(() => {
+      const _current = element.current;
+      if (element && _current) {
+        _current.addEventListener('click', onClick);
+      }
+      return () => {
+        if (element && _current) {
+          _current.removeEventListener('click', onClick);
         }
-
-        const element = useRef();
-
-        useEffect(() => {
-            if (element && element.current) {
-                element.current.addEventListener('click', onClick);
-            }
-            return () => {
-                if (element && element.current) {
-                    element.current.removeEventListener('click', onClick);
-                }
-            };
-        }, []);
-        return element;
-    };
-    const title = useClick(handler);
-    return <div ref={title} className={"answer"}>{ text }</div>;
-}
+      };
+    });
+    return element;
+  };
+  const title = useClick(handler);
+  return (
+    <div ref={title} className={'answer'}>
+      {text}
+    </div>
+  );
+};
 
 export default Answer;

--- a/src/view/Description.jsx
+++ b/src/view/Description.jsx
@@ -9,15 +9,14 @@ import { APP_STATE } from 'constant/stringEnum.js';
 import Button from 'components/Button';
 
 import { isNil } from 'utils/commonUtil';
+import { useMainState } from 'common/customHooks.js';
 
-// import path from 'img/dogs/dog_bedlington.png';
+const Description = ({ setMainState, history }) => {
+  useMainState(APP_STATE.DESC, setMainState);
 
-const Description = ({ type, setState, history }) => {
   const { dogType } = useParams();
 
   const [descInfo, setDescInfo] = useState({});
-
-  setState(APP_STATE.DESC);
 
   /**
    * match.params 의 dogType이 변경되면, descInfo를 세팅한다.
@@ -25,7 +24,8 @@ const Description = ({ type, setState, history }) => {
    */
   useEffect(() => {
     if (!isNil(dogType)) {
-      setDescInfo(() => ({ ...RESULT_DESC_INFO[dogType] }));
+      const upperDogType = dogType.toUpperCase();
+      setDescInfo({ ...RESULT_DESC_INFO[upperDogType] });
     }
     return () => {
       setDescInfo({});

--- a/src/view/Home.jsx
+++ b/src/view/Home.jsx
@@ -5,9 +5,11 @@ import Layout from 'components/Layout';
 import '../scss/home.scss';
 
 import { APP_STATE } from 'constant/stringEnum.js';
+import { useMainState } from 'common/customHooks.js';
 
-const Home = ({ history, setState }) => {
-  setState(APP_STATE.HOME);
+const Home = ({ history, setMainState }) => {
+  // one of customHook
+  useMainState(APP_STATE.HOME, setMainState);
 
   const onStartClick = () => {
     history.push('/research/0');

--- a/src/view/Research.jsx
+++ b/src/view/Research.jsx
@@ -10,8 +10,10 @@ import { TYPE_DOG_MAP } from 'constant/description.js';
 import { CONTENTS } from 'constant/question.js';
 import { APP_STATE } from 'constant/stringEnum.js';
 
-export default function Research({ setState, setType, history }) {
-  setState(APP_STATE.RESEARCH);
+import { useMainState } from 'common/customHooks.js';
+
+export default function Research({ setMainState, setType, history }) {
+  useMainState(APP_STATE.RESEARCH, setMainState);
 
   const [page, setPage] = useState(0);
   const [question, setQuestion] = useState({});
@@ -57,7 +59,6 @@ export default function Research({ setState, setType, history }) {
     addPoint(type);
     updateRate();
     if (page === CONTENTS.length - 1) {
-      setState(APP_STATE.RESULT);
       const mbti = getMbti();
       const _type = getType(mbti);
       setType(_type);

--- a/src/view/result/Confirm.jsx
+++ b/src/view/result/Confirm.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Button from 'components/Button';
 
-const Confirm = ({ type, setState, history }) => {
+const Confirm = ({ type, history }) => {
   const moveDescView = () => {
     if (type) {
       const lowerType = type.toLowerCase();

--- a/src/view/result/Progressive.jsx
+++ b/src/view/result/Progressive.jsx
@@ -22,7 +22,7 @@ const Progressive = ({ setView }) => {
     setTimeout(() => {
       setView(RESULT_VIEWTYPE.CONFIRM);
     }, 2500);
-  }, []);
+  });
 
   return (
     <>

--- a/src/view/result/index.jsx
+++ b/src/view/result/index.jsx
@@ -6,8 +6,13 @@ import { RESULT_VIEWTYPE } from 'constant/stringEnum';
 
 import Progressive from 'view/result/Progressive';
 import Confirm from 'view/result/Confirm';
+import { APP_STATE } from 'constant/stringEnum.js';
 
-const Result = ({ setState, history, type }) => {
+import { useMainState } from 'common/customHooks.js';
+
+const Result = ({ setMainState, history, type }) => {
+  useMainState(APP_STATE.RESULT, setMainState);
+
   const [view, setView] = useState(RESULT_VIEWTYPE.PROGRESSIVE_BAR);
   return (
     <>
@@ -18,7 +23,7 @@ const Result = ({ setState, history, type }) => {
       >
         {!isNil(view) && view === 0 && <Progressive setView={setView} />}
         {!isNil(view) && view === 1 && (
-          <Confirm setState={setState} type={type} history={history} />
+          <Confirm type={type} history={history} />
         )}
       </div>
     </>


### PR DESCRIPTION
App.js 의 state 이름의 state를 mainState로 이름 변경
  - mainState : HOME, RESEARCH, RESULT, DESC ....
  
mainState를 변경하는 customHook 추가

setMainState 호출 시점 변경
  - as-is: 기존에는 화면을 이동하기 전의 컴포넌트에서 미리 다음 컴포넌트의 mainState를 세팅해주었음
  - to-be: 자기 자신 컴포넌트에서 자신에 해당하는 mainState 세팅 e.g. Research 컴포넌트가 렌더링 될 때, mainState를 RESEARCH 로 세팅

  - 이유 : 라우팅을 적용했기 때문에, url로 접근했을 경우, 기존 방식대로라면 화면에 표현되는 컴포넌트와 mainState와 차이 발생

useClick 커스텀 훅 수정
  - 내부에서 사용하는 useEffect의 return 함수는 아래 두 가지 경우에 의해서 호출됨
     1. 의존성 배열에 해당하는 데이터가 변경되어, 이전의 Effect 초기화
     2. 해당 컴포넌트가 unmount 될 때 (화면에서 내려올 때)
  - return 함수 내부에서 초기화 시  사용하는 element.current 값이 이전과 다를 수 있기 때문에 초기화를 위해 변수에 할당