### PR TITLE
Router navigation guard 적용

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { BrowserRouter, Route, Switch } from 'react-router-dom';
 
 import { APP_STATE } from 'constant/stringEnum';
 
+import GuardRoute from './router/GuardRoute';
 import Home from 'view/Home';
 import Research from 'view/Research';
 import Result from 'view/result';
@@ -12,67 +13,66 @@ import Description from 'view/Description';
 function App() {
   const [mainState, setMainState] = useState(APP_STATE.HOME);
   const [type, setType] = useState('');
+  const [isActive, setIsActive] = useState(false);
 
   /**
    * state가 HOME 일 경우, type 을 초기화한다.
    * @author  uhjee
    */
   useEffect(() => {
-    if (mainState && mainState === APP_STATE.HOME) setType('');
+    if (mainState && mainState === APP_STATE.HOME) {
+      setIsActive(false);
+      setType('');
+    }
   }, [mainState]);
 
   return (
-    <BrowserRouter>
-      <Switch>
-        <>
-          <div
-            className={`main-container${
-              mainState === APP_STATE.DESC ? ' olive' : ''
-            }`}
-          >
-            <Route
-              exact
-              path="/"
-              render={({ history }) => (
-                <Home history={history} setMainState={setMainState} />
-              )}
-            />
-            <Route
-              path="/research/:pageNum"
-              render={({ history }) => (
-                <Research
-                  history={history}
-                  setMainState={setMainState}
-                  setType={setType}
-                />
-              )}
-            />
-            <Route
-              exact
-              path="/result"
-              render={({ history, match }) => (
-                <Result
-                  history={history}
-                  match={match}
-                  setMainState={setMainState}
-                  type={type}
-                />
-              )}
-            />
-            <Route
-              path="/desc/:dogType"
-              render={({ history }) => (
-                <Description
-                  type={type}
-                  history={history}
-                  setMainState={setMainState}
-                />
-              )}
-            />
-          </div>
-        </>
-      </Switch>
-    </BrowserRouter>
+    <div
+      className={`main-container${
+        mainState === APP_STATE.DESC ? ' olive' : ''
+      }`}
+    >
+      <BrowserRouter>
+        <Switch>
+          <Route
+            exact
+            path="/"
+            render={({ history }) => (
+              <Home
+                history={history}
+                setIsActive={setIsActive}
+                setMainState={setMainState}
+              />
+            )}
+          />
+          <GuardRoute
+            path="/research/:pageNum"
+            component={Research}
+            isActive={isActive}
+            setMainState={setMainState}
+            setType={setType}
+          />
+          <GuardRoute
+            exact
+            path="/result"
+            component={Result}
+            isActive={isActive}
+            setMainState={setMainState}
+            type={type}
+          />
+          <Route
+            path="/desc/:dogType"
+            render={({ history }) => (
+              <Description
+                type={type}
+                history={history}
+                setMainState={setMainState}
+              />
+            )}
+          />
+        </Switch>
+      </BrowserRouter>
+    </div>
   );
 }
 export default App;

--- a/src/router/GuardRoute.jsx
+++ b/src/router/GuardRoute.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Route, Redirect } from 'react-router-dom';
+
+/**
+ * url로 직접 네비게이션 되지 않도록 isActive 여부에 따라 렌더링 여부를 판단해 Route 컴포넌트를 반환하는 컴포넌트
+ * @author  uhjee
+ * @param {*} param0
+ * @returns
+ */
+const GuardRoute = ({ component: Component, isActive, ...rest }) => (
+  <Route
+    {...rest}
+    render={props =>
+      isActive ? <Component {...props} {...rest} /> : <Redirect to="/" />
+    }
+  />
+);
+
+export default GuardRoute;

--- a/src/view/Home.jsx
+++ b/src/view/Home.jsx
@@ -7,11 +7,12 @@ import '../scss/home.scss';
 import { APP_STATE } from 'constant/stringEnum.js';
 import { useMainState } from 'common/customHooks.js';
 
-const Home = ({ history, setMainState }) => {
+const Home = ({ history, setMainState, setIsActive }) => {
   // one of customHook
   useMainState(APP_STATE.HOME, setMainState);
 
   const onStartClick = () => {
+    setIsActive(true);
     history.push('/research/0');
   };
 


### PR DESCRIPTION
GuardRoute 이름의 컴포넌트 생성
  - Route 컴포넌트를 한 번 감싸서, props의 isActive 속성이 true일 경우에만, Route 컴포넌트 생성
  - isActive가 false라면 홈 화면으로 라우팅

App.js 에 isActive  state 생성
  - 사용자가 url로 직접 ~/research/3 을 입력해 접근하지 못하도록 판단하기 위한 플래그
  - Home 화면에서 Start 버튼을 눌러야 isActive가 true로 변경
  - 다시 Home 화면으로 돌아오면, false로 세팅

GuardRoute 컴포넌트로 Research, Result 화면 감쌈
  - 사용자의 비정상적 접근이 허용되지 않는 컴포넌트들
  - Description은 카카오톡 공유 등, 직접 url을 통해 공유해야하기 때문에 GuardRoute 컴포넌트 사용 X